### PR TITLE
fix micro building error on windows10 (#436)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/hako/branca v0.0.0-20180808000428-10b799466ada
 	github.com/micro/cli v0.2.0
-	github.com/micro/go-micro v1.16.1-0.20191122171000-38e29c510192
+	github.com/micro/go-micro v1.16.1-0.20191123082556-cae4148594da
 	github.com/miekg/dns v1.1.22
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/service/handler/exec/exec.go
+++ b/service/handler/exec/exec.go
@@ -89,10 +89,9 @@ func (p *Proxy) ServeRequest(ctx context.Context, req server.Request, rsp server
 		}
 	}
 
-	return nil
 }
 
-// NewFileProxy returns a router which sends requests to a single file
+//NewSingleHostProxy returns a router which sends requests to a single file
 func NewSingleHostProxy(url string) proxy.Proxy {
 	return &Proxy{
 		Endpoint: url,

--- a/service/handler/file/file.go
+++ b/service/handler/file/file.go
@@ -15,6 +15,7 @@ import (
 	"github.com/micro/go-micro/server"
 )
 
+//Proxy for a proxy instance
 type Proxy struct {
 	options.Options
 
@@ -44,6 +45,7 @@ func getEndpoint(hdr map[string]string) string {
 	return ""
 }
 
+//SendRequest currrent just return error.
 func (p *Proxy) SendRequest(ctx context.Context, req client.Request, rsp client.Response) error {
 	return errors.InternalServerError("go.micro.proxy.http", "SendRequest is unsupported")
 }
@@ -100,10 +102,9 @@ func (p *Proxy) ServeRequest(ctx context.Context, req server.Request, rsp server
 		}
 	}
 
-	return nil
 }
 
-// NewFileProxy returns a router which sends requests to a single file
+//NewSingleHostProxy returns a Proxy which stand for a endpoint.
 func NewSingleHostProxy(url string) proxy.Proxy {
 	return &Proxy{
 		Endpoint: url,


### PR DESCRIPTION
* fix micro building error on windows by update to go-micro to github.com/micro/go-micro v1.16.1-0.20191123082556-cae4148594da

* clean code & remove unreachable code